### PR TITLE
Monospace for links to changeset

### DIFF
--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -8,7 +8,7 @@ h2, .wiki h1 {font-size: 20px;}
 h3, .wiki h2 {font-size: 16px;}
 h4, .wiki h3 {font-size: 13px;}
 h4 {border-bottom: 1px solid #ccc; font-weight:normal;}
-pre, code {font-family: Consolas, Menlo, "Liberation Mono", Courier, monospace;}
+pre, code, a.changeset {font-family: Consolas, Menlo, "Liberation Mono", Courier, monospace;}
 
 /***** Layout *****/
 div#wrapper, div#wrapper2, div#wrapper3 { min-height: inherit; }


### PR DESCRIPTION
How about displaying links to changeset in monospace?

Before:
  <img width="712" alt="image" src="https://user-images.githubusercontent.com/16700/96123283-91dc2200-0f2d-11eb-8ea0-d5516146b60b.png">

After:
  <img width="712" alt="image" src="https://user-images.githubusercontent.com/16700/96125907-ee8c0c80-0f2e-11eb-9d3d-8b3ecdbd90a3.png">
